### PR TITLE
ChromaShiftSP2: Fix incorrect shifting

### DIFF
--- a/ChromaShiftSP2_.avsi
+++ b/ChromaShiftSP2_.avsi
@@ -4,6 +4,8 @@
 
 ### Changelog ###
 #---------------
+# Fix incorrect shifting.
+#---------------
 # Changed UX/UY/VX/VY from chroma pixels to luma pixels.
 #---------------
 # Added high bit-depth support.
@@ -16,14 +18,17 @@ Function ChromaShiftSP2 (clip clp, float "UX",float "UY", float "VX",float "VY",
     VX = default(VX, 0.0) # positive values shift the V chroma to left, negative values to right
     VY = default(VY, 0.0) # positive values shift the V chroma upwards, negative values downwards
     ResizeMethod = Default(ResizeMethod, "Spline36")
-    
+
     ucw = (Is420(clp) || Is422(clp)) ? UX / 2.0 : UX
     uch = (Is444(clp) || Is422(clp)) ? UY : UY / 2.0
     vcw = (Is420(clp) || Is422(clp)) ? VX / 2.0 : VX
     vch = (Is444(clp) || Is422(clp)) ? VY : VY / 2.0
-    
-    U = ExtractU(clp)
-    V = ExtractV(clp)
-    
-    return CombinePlanes(ExtractY(clp), Eval("U." + ResizeMethod + "Resize(U.Width(), U.Height(), ucw, uch, U.Width()+ucw, U.Height()+uch)"), Eval("V." + ResizeMethod + "Resize(V.Width(), V.Height(), vcw, vch, V.Width()+vcw, V.Height()+vch)"), planes="YUV", sample_clip=clp)
+
+    uvw = (!Is444(clp)) ? Width(clp) / 2 : Width(clp)
+    uvh = (Is420(clp)) ? Height(clp) / 2 : Height(clp)
+
+    U = ExtractU(clp).Eval(+ ResizeMethod + "Resize(uvw, uvh, src_left=ucw, src_top=uch)")
+    V = ExtractV(clp).Eval(+ ResizeMethod + "Resize(uvw, uvh, src_left=vcw, src_top=vch)")
+
+    Return CombinePlanes(clp, U, V, planes="YUV", source_planes="YYY", sample_clip=clp)
 }


### PR DESCRIPTION
I noticed odd shifting behavior with ChromaShiftSP2 which is better explained by seeing the results of the test script below. The results are more inconsistent when the shift values are positive, but even with negative values, something seems off.

Test image: https://i.ibb.co/9ydxXwQ/IMG-4850-4.png


```
FFImageSource("IMG_4850-4.png")
ConvertToYV24()

x = 4
y = 4
a = last
b = ChromaShiftSP2(last, VX=x, VY=y)
c = DumbChromaShift(last, VX=x, VY=y)
d = ChromaShiftSP2o(last, VX=x, VY=y) # original script

Interleave(a,b,c,d)
ExtractV()

# ChromaShiftSP2: Shift U & V chroma separately with subpixel accuracy, based on the ChromaShiftSP function by IanB & McCauley
# https://forum.doom9.org/showthread.php?p=1851933#post1851933


### Changelog ###
#---------------
# Fix incorrect shifting.
#---------------
# Changed UX/UY/VX/VY from chroma pixels to luma pixels.
#---------------
# Added high bit-depth support.


Function ChromaShiftSP2 (clip clp, float "UX",float "UY", float "VX",float "VY", string "ResizeMethod")
{
    UX = default(UX, 0.0) # positive values shift the U chroma to left, negative values to right
    UY = default(UY, 0.0) # positive values shift the U chroma upwards, negative values downwards
    VX = default(VX, 0.0) # positive values shift the V chroma to left, negative values to right
    VY = default(VY, 0.0) # positive values shift the V chroma upwards, negative values downwards
    ResizeMethod = Default(ResizeMethod, "Spline36")

    ucw = (Is420(clp) || Is422(clp)) ? UX / 2.0 : UX
    uch = (Is444(clp) || Is422(clp)) ? UY : UY / 2.0
    vcw = (Is420(clp) || Is422(clp)) ? VX / 2.0 : VX
    vch = (Is444(clp) || Is422(clp)) ? VY : VY / 2.0

    uvw = (!Is444(clp)) ? Width(clp) / 2 : Width(clp)
    uvh = (Is420(clp)) ? Height(clp) / 2 : Height(clp)

    U = ExtractU(clp).Eval(+ ResizeMethod + "Resize(uvw, uvh, src_left=ucw, src_top=uch)")
    V = ExtractV(clp).Eval(+ ResizeMethod + "Resize(uvw, uvh, src_left=vcw, src_top=vch)")

    Return CombinePlanes(clp, U, V, planes="YUV", source_planes="YYY", sample_clip=clp)
}

Function DumbChromaShift (clip input, int "UX", int "UY", int "VX", int "VY") {
    UX = default(UX, 0) # positive values shift the U chroma to left, negative values to right
    UY = default(UY, 0) # positive values shift the U chroma upwards, negative values downwards
    VX = default(VX, 0) # positive values shift the V chroma to left, negative values to right
    VY = default(VY, 0) # positive values shift the V chroma upwards, negative values downwards

    UL = (UX > 0) ? abs(UX) : 0
    UR = (UX < 0) ? abs(UX) : 0
    UU = (UY > 0) ? abs(UY) : 0
    UD = (UY < 0) ? abs(UY) : 0
    VL = (VX > 0) ? abs(VX) : 0
    VR = (VX < 0) ? abs(VX) : 0
    VU = (VY > 0) ? abs(VY) : 0
    VD = (VY < 0) ? abs(VY) : 0

    U= ExtractU(input).Crop(UL, UU, -UR, -UD).AddBorders(UR, UD, UL, UU)
    V= ExtractV(input).Crop(VL, VU, -VR, -VD).AddBorders(VR, VD, VL, VU)
    Return YToUV(U,V,input)
}

# ChromaShiftSP2: Shift U & V chroma separately with subpixel accuracy, based on the ChromaShiftSP function by IanB & McCauley
# https://forum.doom9.org/showthread.php?p=1851933#post1851933


### Changelog ###
#---------------
# Changed UX/UY/VX/VY from chroma pixels to luma pixels.
#---------------
# Added high bit-depth support.

#Original
Function ChromaShiftSP2o (clip clp, float "UX",float "UY", float "VX",float "VY", string "ResizeMethod")
{
    UX = default(UX, 0.0) # positive values shift the U chroma to left, negative values to right
    UY = default(UY, 0.0) # positive values shift the U chroma upwards, negative values downwards
    VX = default(VX, 0.0) # positive values shift the V chroma to left, negative values to right
    VY = default(VY, 0.0) # positive values shift the V chroma upwards, negative values downwards
    ResizeMethod = Default(ResizeMethod, "Spline36")

    ucw = (Is420(clp) || Is422(clp)) ? UX / 2.0 : UX
    uch = (Is444(clp) || Is422(clp)) ? UY : UY / 2.0
    vcw = (Is420(clp) || Is422(clp)) ? VX / 2.0 : VX
    vch = (Is444(clp) || Is422(clp)) ? VY : VY / 2.0

    U = ExtractU(clp)
    V = ExtractV(clp)

    return CombinePlanes(ExtractY(clp), Eval("U." + ResizeMethod + "Resize(U.Width(), U.Height(), ucw, uch, U.Width()+ucw, U.Height()+uch)"), Eval("V." + ResizeMethod + "Resize(V.Width(), V.Height(), vcw, vch, V.Width()+vcw, V.Height()+vch)"), planes="YUV", sample_clip=clp)
}
```